### PR TITLE
Ignore comment sections within wiki page text

### DIFF
--- a/osmwiki.py
+++ b/osmwiki.py
@@ -12,6 +12,7 @@ import datetime
 import logging
 import urllib
 import time
+import re
 
 
 def loadAllUserGroups(user, password):
@@ -81,6 +82,11 @@ def __getTemplateAttributes(page):
     attrs = {}  # the parsed dictionary of the template attributes
     source = page.getWikiText(False).decode("utf-8")  # API uses UTF-8
     source = urllib.unquote(source).replace('\n', "")
+
+    # remove comments
+    commentMatcher = re.compile("<!--.*?-->")
+    source = commentMatcher.sub("", source)
+
     # extract template and cut it's attributes
     start = source.find("{{user group") + len("{{user group") + 1
     end = source.find("}}", start)


### PR DESCRIPTION
The wiki page of the [local group of Hamburg, Germany](https://wiki.openstreetmap.org/wiki/Hamburger_Mappertreffen) contains an older version of the user group box (from pre-covid times) and a newer version. The older version is within a huge comment block but is still evaluated by this bot.

I also can imagine that other pages use comments within their page as well.