### PR TITLE
7 attributeerror type object  iostringio has no attribute stringio trying request again in 5 seconds

### DIFF
--- a/wikitools3/api.py
+++ b/wikitools3/api.py
@@ -35,9 +35,8 @@ canupload = True
 import json
 
 try:
-    #import gzip
-    #from io import StringIO
-    gzip = False
+    import gzip
+    import  io
 except:
     gzip = False
 
@@ -278,7 +277,7 @@ for queries requring multiple requests""",
                     encoding = self.response.get("Content-encoding")
                     if encoding in ("gzip", "x-gzip"):
                         data = gzip.GzipFile(
-                            "", "rb", 9, StringIO.StringIO(data.read())
+                            None, "rb", 9, io.BytesIO(data.read())
                         )
             except catcherror as exc:
                 errname = sys.exc_info()[0].__name__

--- a/wikitools3/api.py
+++ b/wikitools3/api.py
@@ -35,8 +35,9 @@ canupload = True
 import json
 
 try:
-    import gzip
-    from io import StringIO
+    #import gzip
+    #from io import StringIO
+    gzip = False
 except:
     gzip = False
 


### PR DESCRIPTION
GZIP erwartet einen BytesIO Stream anstatt wie bisher einen StringIO Stream. Siehe auch https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit